### PR TITLE
Bumped Junit Jupiter version

### DIFF
--- a/coffee4j-junit-jupiter/src/main/java/de/rwth/swc/coffee4j/junit/CombinatorialTestMethodContext.java
+++ b/coffee4j-junit-jupiter/src/main/java/de/rwth/swc/coffee4j/junit/CombinatorialTestMethodContext.java
@@ -163,7 +163,7 @@ public class CombinatorialTestMethodContext {
         @Override
         public Object resolve(ParameterContext parameterContext, Combination testInput, InputParameterModel model) {
             
-            final ArgumentsAccessor accessor = new DefaultArgumentsAccessor(IntStream.range(0, model.size()).mapToObj(index -> model.getParameters().get(index)).map(testInput::getRawValue).toArray());
+            final ArgumentsAccessor accessor = new DefaultArgumentsAccessor(parameterContext, 1, IntStream.range(0, model.size()).mapToObj(index -> model.getParameters().get(index)).map(testInput::getRawValue).toArray());
             try {
                 return argumentsAggregator.aggregateArguments(accessor, parameterContext);
             } catch (Exception e) {

--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,8 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <slf4j.version>1.7.25</slf4j.version>
-        <junit-jupiter.version>5.3.2</junit-jupiter.version>
-        <junit-platform.version>1.3.2</junit-platform.version>
+        <junit-jupiter.version>5.10.0</junit-jupiter.version>
+        <junit-platform.version>1.10.0</junit-platform.version>
         <mockito.version>2.18.0</mockito.version>
         <choco-solver.version>4.10.0</choco-solver.version>
         <fastutil.version>8.2.3</fastutil.version>


### PR DESCRIPTION
Our BOM uses the newest version which leads to dependency conflicts in TLS-Anvil